### PR TITLE
Fix jacoco on the maven projects

### DIFF
--- a/projects/CoreBanking/pom.xml
+++ b/projects/CoreBanking/pom.xml
@@ -17,6 +17,13 @@
       <version>4.8.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <version>0.8.5</version>
+      <scope>test</scope>
+      <classifier>runtime</classifier>
+    </dependency>
   </dependencies>
   <build>
     <plugins>
@@ -48,6 +55,35 @@
           <source>1.8</source>
           <target>1.8</target>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M3</version>
+        <configuration>
+          <argLine>-Djacoco-agent.destfile=${project.build.directory}/jacoco.exec</argLine>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.5</version>
+        <executions>
+          <execution>
+            <id>instrument</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>instrument</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>restore-instrumented-classes</id>
+            <phase>test</phase>
+            <goals>
+              <goal>restore-instrumented-classes</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/projects/Twitter--GraphJet/graphjet-adapters/pom.xml
+++ b/projects/Twitter--GraphJet/graphjet-adapters/pom.xml
@@ -41,5 +41,13 @@
       <artifactId>metrics</artifactId>
       <version>0.0.38</version>
     </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <version>0.8.5</version>
+      <scope>test</scope>
+      <classifier>runtime</classifier>
+    </dependency>
+
   </dependencies>
 </project>

--- a/projects/Twitter--GraphJet/graphjet-core/pom.xml
+++ b/projects/Twitter--GraphJet/graphjet-core/pom.xml
@@ -65,5 +65,13 @@
       <version>1.7.21</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <version>0.8.5</version>
+      <scope>test</scope>
+      <classifier>runtime</classifier>
+    </dependency>
+
   </dependencies>
 </project>

--- a/projects/Twitter--GraphJet/graphjet-demo/pom.xml
+++ b/projects/Twitter--GraphJet/graphjet-demo/pom.xml
@@ -58,5 +58,12 @@
       <artifactId>args4j</artifactId>
       <version>2.32</version>
     </dependency>
+    <dependency>
+      <groupId>org.jacoco</groupId>
+      <artifactId>org.jacoco.agent</artifactId>
+      <version>0.8.5</version>
+      <scope>test</scope>
+      <classifier>runtime</classifier>
+    </dependency>
   </dependencies>
 </project>

--- a/projects/Twitter--GraphJet/pom.xml
+++ b/projects/Twitter--GraphJet/pom.xml
@@ -67,6 +67,7 @@
         <configuration>
           <forkMode>always</forkMode>
           <argLine>-Xmx1024m</argLine>
+          <argLine>-Djacoco-agent.destfile=${project.build.directory}/jacoco.exec</argLine>
         </configuration>
       </plugin>
       <plugin>
@@ -95,6 +96,27 @@
             <configuration>
               <additionalparam>-Xdoclint:none</additionalparam>
             </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.5</version>
+        <executions>
+          <execution>
+            <id>instrument</id>
+            <phase>process-test-classes</phase>
+            <goals>
+              <goal>instrument</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>restore-instrumented-classes</id>
+            <phase>test</phase>
+            <goals>
+              <goal>restore-instrumented-classes</goal>
+            </goals>
           </execution>
         </executions>
       </plugin>

--- a/projects/waltz/waltz-common/pom.xml
+++ b/projects/waltz/waltz-common/pom.xml
@@ -94,5 +94,45 @@
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <version>0.8.5</version>
+            <scope>test</scope>
+            <classifier>runtime</classifier>
+        </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M3</version>
+                <configuration>
+                    <argLine>-Djacoco-agent.destfile=${project.build.directory}/jacoco.exec</argLine>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.5</version>
+                <executions>
+                    <execution>
+                        <id>instrument</id>
+                        <phase>process-test-classes</phase>
+                        <goals>
+                            <goal>instrument</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>restore-instrumented-classes</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
Now CoreBanking, all Twitter-GraphJet modules, waltz-common and pet-clinic will generate jacoco reports when run with the command `mvn clean test jacoco:report`
The gradle one however is another story